### PR TITLE
#5 Adds method for normalizing pixel intensity relationship

### DIFF
--- a/src/dicom_image_tools/dicom_handlers/projection.py
+++ b/src/dicom_image_tools/dicom_handlers/projection.py
@@ -139,6 +139,9 @@ class ProjectionSeries(DicomSeries):
             dcm = pydicom.dcmread(str(fp.absolute()))
             self.ImageVolume.append(get_pixel_array(dcm=dcm))
 
+        if self.PixelIntensityNormalized:
+            self.normalize_pixel_intensity_relationship()
+
     def sort_images_on_acquisition_time(self) -> None:
         """Reorder the images in the series based on the acquisition time
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,22 @@
+import numpy as np
+from pydicom.dataset import Dataset, FileDataset
+from pytest import fixture
+
+
+@fixture(scope="function")
+def image_with_negative_pixel_intensity_relationship():
+    ds: Dataset = Dataset()
+    ds.PixelIntensityRelationshipSign = -1
+    ds.BitsStored = 12
+
+    return {
+        "image": np.array([
+            [0, 0, 0],
+            [2**10, 2**10, 2**10]
+        ]),
+        "normalized_image": np.multiply(np.array([
+            [-2**ds.BitsStored, -2**ds.BitsStored, -2**ds.BitsStored],
+            [2**10-2**ds.BitsStored, 2**10-2**ds.BitsStored, 2**10-2**ds.BitsStored]
+        ]), -1),
+        "metadata": ds
+    }

--- a/tests/unit/test_dicom_series_methods.py
+++ b/tests/unit/test_dicom_series_methods.py
@@ -1,0 +1,76 @@
+import numpy as np
+import pytest
+
+from dicom_image_tools.dicom_handlers.dicom_series import DicomSeries
+
+
+def test_normalize_pixel_intensity_relationship_should_reverse_pixel_intensities_when_pixel_intensity_relationship_sign_is_negative(image_with_negative_pixel_intensity_relationship):
+    # Arrange
+    series = DicomSeries("TestSeries")
+    series.CompleteMetadata.append(image_with_negative_pixel_intensity_relationship.get("metadata"))
+    series.ImageVolume = [image_with_negative_pixel_intensity_relationship.get("image")]
+    expected = image_with_negative_pixel_intensity_relationship.get("normalized_image")
+
+    # Act
+    series.normalize_pixel_intensity_relationship()
+
+    # Assert
+    assert np.equal(expected, series.ImageVolume).all()
+
+
+def test_normalize_pixel_intensity_relationship_should_set_PixelIntensityNormailzed_to_True(
+        image_with_negative_pixel_intensity_relationship):
+    # Arrange
+    series = DicomSeries("TestSeries")
+    series.CompleteMetadata.append(image_with_negative_pixel_intensity_relationship.get("metadata"))
+    series.ImageVolume = [image_with_negative_pixel_intensity_relationship.get("image")]
+
+    assert series.PixelIntensityNormalized == False
+
+    # Act
+    series.normalize_pixel_intensity_relationship()
+
+    # Assert
+    assert series.PixelIntensityNormalized
+
+
+def test_normalize_pixel_intensity_relationship_should_return_do_nothing_if_PixelIntensityNormailzed_is_True(
+        image_with_negative_pixel_intensity_relationship):
+    # Arrange
+    series = DicomSeries("TestSeries")
+    series.CompleteMetadata.append(image_with_negative_pixel_intensity_relationship.get("metadata"))
+    series.ImageVolume = [image_with_negative_pixel_intensity_relationship.get("image")]
+    series.PixelIntensityNormalized = True
+    expected = image_with_negative_pixel_intensity_relationship.get("image").copy()
+
+    # Act
+    series.normalize_pixel_intensity_relationship()
+
+    # Assert
+    assert np.equal(expected, series.ImageVolume).all()
+
+
+def test_normalize_pixel_intensity_relationship_should_return_do_nothing_if_PixelIntensityRelationshipSign_is_1(
+        image_with_negative_pixel_intensity_relationship):
+    # Arrange
+    series = DicomSeries("TestSeries")
+    series.CompleteMetadata.append(image_with_negative_pixel_intensity_relationship.get("metadata"))
+    series.ImageVolume = [image_with_negative_pixel_intensity_relationship.get("image")]
+    series.CompleteMetadata[0].PixelIntensityRelationshipSign = 1
+    expected = image_with_negative_pixel_intensity_relationship.get("image").copy()
+
+    # Act
+    series.normalize_pixel_intensity_relationship()
+
+    # Assert
+    assert np.equal(expected, series.ImageVolume).all()
+
+
+def test_normalize_pixel_intensity_relationship_raises_ValueError_if_image_volume_is_not_imported(
+        image_with_negative_pixel_intensity_relationship):
+    # Arrange
+    series = DicomSeries("TestSeries")
+    series.CompleteMetadata.append(image_with_negative_pixel_intensity_relationship.get("metadata"))
+
+    with pytest.raises(ValueError):
+        series.normalize_pixel_intensity_relationship()


### PR DESCRIPTION
Adds functionality for normalizing the pixel intensity relationship to a state where a lower pixel value correspond to less X-Ray beam intensity.

Also adds an attribute on _DicomSeries_ to keep track of if this normalization has been performed.

Closes #5 