### PR TITLE
Changes inversion reference value to BitsAllocated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (Path(__file__).parent / "README.md").read_text()
 
 setup(
     name="dicom_image_tools",
-    version="23.1.4",
+    version="23.2.0",
     description="Python package for managing DICOM images from different modalities",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/src/dicom_image_tools/dicom_handlers/dicom_series.py
+++ b/src/dicom_image_tools/dicom_handlers/dicom_series.py
@@ -103,7 +103,7 @@ class DicomSeries:
         if metadata.PixelIntensityRelationshipSign == 1:
             return image
 
-        image = np.multiply(image - np.power(2, metadata.BitsStored), -1)
+        image = np.multiply(image - np.power(2, metadata.BitsAllocated), -1)
 
         return image
 


### PR DESCRIPTION
Changes the reference (maximum value) for pixel inversion used when the `PixelIntensityRelationshipSign = -1` from the tag `BitsStored` to the tag `BitsAllocated`